### PR TITLE
use linux-64 to build linux-ppc64le

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @danclewley @gillins @ocefpaf @xylar
+* @akrherz @danclewley @gillins @ocefpaf @xylar

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-
+* [@akrherz](https://github.com/akrherz/)
 * [@danclewley](https://github.com/danclewley/)
 * [@gillins](https://github.com/gillins/)
 * [@ocefpaf](https://github.com/ocefpaf/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,11 +21,15 @@ source:
     - gh71_check_drop_rename.patch
 
 build:
-  number: 7
+  number: 8
   skip: true  # [win and vc<14]
   run_exports:
     # No idea.  Staying with minor version pin.
     - {{ pin_subpackage('libspatialite', max_pin='x.x') }}
+
+# workaround unknown Travis-CI hangs on PPC64LE
+build_platform:
+  linux-ppc64le: linux-64
 
 requirements:
   build:


### PR DESCRIPTION
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

@conda-forge-admin, please rerender

Suggested workaround to ppc64le builds hanging on Travis-CI.